### PR TITLE
tests/boot: Fix lookup of supported boards

### DIFF
--- a/boards/__init__.py
+++ b/boards/__init__.py
@@ -53,10 +53,10 @@ def detect():
 
         raise IOError
 
-path = os.path.dirname(__file__)
+parent = os.path.dirname(__file__)
 
-for directory in os.listdir(path):
-    path = os.path.join(path, directory)
+for directory in os.listdir(parent):
+    path = os.path.join(parent, directory)
 
     if os.path.exists(os.path.join(path, '__init__.py')):
         name = 'boards.%s' % directory


### PR DESCRIPTION
When iterating through the directory list, directories of the same
parent directory are appended to each other causing an invalid path
and this in turn can cause the boards/__init__.py script to fail to
find any supported boards.

This particularly a problem when the __pycache__ directory is created
under the 'boards' directory and so there is more than one directory
to search. Fix this by defining a 'parent' directory variable which is
not updated as we iterate through the list for directories.

Signed-off-by: Jon Hunter <jonathanh@nvidia.com>