### PR TITLE
boards: Add 'urandom_read' warning to whitelist

### DIFF
--- a/boards/nvidia/jetson-tk1.py
+++ b/boards/nvidia/jetson-tk1.py
@@ -80,4 +80,5 @@ class Board(boards.Board):
         r'pci [0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F]: nv_msi_ht_cap_quirk didn\'t locate host bridge',
         r'platform regulatory.0: Direct firmware load for regulatory.db failed with error -2',
         r'tegra-hdmi 54280000.hdmi: cannot set audio to 48000 Hz at 297000000 Hz pixel clock',
+        r'urandom_read: [0-9]+ callbacks suppressed',
     ]

--- a/boards/nvidia/jetson-tx1.py
+++ b/boards/nvidia/jetson-tx1.py
@@ -40,3 +40,7 @@ class Board(boards.Board):
         # USB bus
         sysfs.Device('usb', '2-1:1.0', 'r8152'),
     ]
+
+    whitelist = [
+        r'urandom_read: [0-9]+ callbacks suppressed',
+    ]

--- a/boards/nvidia/jetson-tx2.py
+++ b/boards/nvidia/jetson-tx2.py
@@ -8,3 +8,7 @@ class Board(boards.Board):
         # platform bus
         # I2C bus
     ]
+
+    whitelist = [
+        r'urandom_read: [0-9]+ callbacks suppressed',
+    ]

--- a/boards/nvidia/jetson-xavier.py
+++ b/boards/nvidia/jetson-xavier.py
@@ -36,4 +36,5 @@ class Board(boards.Board):
         r'mmc1: Unknown controller version \(5\). You may experience problems.',
         r'tegra-dpaux 155e0000.dpaux: 155e0000.dpaux supply vdd not found, using dummy regulator',
         r'\[drm\] parse error at position 6 in video mode \'tegrafb\'',
+        r'urandom_read: [0-9]+ callbacks suppressed',
     ]


### PR DESCRIPTION
During boot messages such as the following maybe seen ...

     WARNING KERN urandom_read: 6 callbacks suppressed

These may occur if there is not enough entropy available when urandom
is read. Although this should be fixed by adding more entropy sources,
given that this has always occurred when booting upstream Linux kernels
on Tegra, whitelist this for now.

Signed-off-by: Jon Hunter <jonathanh@nvidia.com>