### PR TITLE
boards: Update Orin board files spiking some warnings for Ubuntu for Jetson

### DIFF
--- a/boards/nvidia/jetson-agx-orin.py
+++ b/boards/nvidia/jetson-agx-orin.py
@@ -260,6 +260,9 @@ class Board(boards.Board):
         r'platform regulatory.0: Falling back to sysfs fallback for: regulatory.db',
         r'IRQ\d*: set affinity failed\(-22\).',
         r'nvme nvme0: missing or invalid SUBNQN field.',
+        r'SPI driver altr_a10sr has no spi_device_id for altr,a10sr',
+        r'device-mapper: core: CONFIG_IMA_DISABLE_HTABLE is disabled. Duplicate IMA measurements will not be recorded in the IMA log.',
+        r'NVRM rpcRmApiControl_dce: NVRM_RPC_DCE: Failed RM ctrl call cmd:0x731341 result 0xffff:',
     ]
 
     # Add additional dmesg warn, err here that are to be ignored in the logs test

--- a/boards/nvidia/jetson-orin-nano.py
+++ b/boards/nvidia/jetson-orin-nano.py
@@ -229,6 +229,10 @@ class Board(boards.Board):
         r'platform regulatory.0: Falling back to sysfs fallback for: regulatory.db',
         r'IRQ\d*: set affinity failed\(-22\).',
         r'nvme nvme0: missing or invalid SUBNQN field.',
+        r'SPI driver altr_a10sr has no spi_device_id for altr,a10sr',
+        r'device-mapper: core: CONFIG_IMA_DISABLE_HTABLE is disabled. Duplicate IMA measurements will not be recorded in the IMA log.',
+        r'NVRM rpcRmApiControl_dce: NVRM_RPC_DCE: Failed RM ctrl call cmd:0x731341 result 0xffff:',
+        r'r8168  Copyright \(C\) 2024 Realtek NIC software team <nicfae@realtek.com> \\x0a This program comes with ABSOLUTELY NO WARRANTY; for details, please see <http://www.gnu.org/licenses/>. \\x0a This is free software, and you are welcome to redistribute it under certain conditions; see <http://www.gnu.org/licenses/>.',
     ]
 
     # Add additional dmesg warn, err here that are to be ignored in the logs test

--- a/boards/nvidia/jetson-orin-nx.py
+++ b/boards/nvidia/jetson-orin-nx.py
@@ -244,6 +244,10 @@ class Board(boards.Board):
         r'platform regulatory.0: Falling back to sysfs fallback for: regulatory.db',
         r'IRQ\d*: set affinity failed\(-22\).',
         r'nvme nvme0: missing or invalid SUBNQN field.',
+        r'SPI driver altr_a10sr has no spi_device_id for altr,a10sr',
+        r'device-mapper: core: CONFIG_IMA_DISABLE_HTABLE is disabled. Duplicate IMA measurements will not be recorded in the IMA log.',
+        r'NVRM rpcRmApiControl_dce: NVRM_RPC_DCE: Failed RM ctrl call cmd:0x731341 result 0xffff:',
+        r'r8168  Copyright \(C\) 2024 Realtek NIC software team <nicfae@realtek.com> \\x0a This program comes with ABSOLUTELY NO WARRANTY; for details, please see <http://www.gnu.org/licenses/>. \\x0a This is free software, and you are welcome to redistribute it under certain conditions; see <http://www.gnu.org/licenses/>.',
     ]
 
     # Add additional dmesg warn, err here that are to be ignored in the logs test


### PR DESCRIPTION
# Description

This PR is based on Canonical testing when running the `tegra-tests` tool on the Ubuntu Kernel.

- Skiplist the following benign Kernel warnings on the AGX Orin, Orin Nano/NX board files:
  - SPI driver altr_a10sr has no spi_device_id for altr,a10sr
  - device-mapper: core: CONFIG_IMA_DISABLE_HTABLE is disabled. Duplicate IMA measurements will not be recorded in the IMA log.
  - NVRM rpcRmApiControl_dce: NVRM_RPC_DCE: Failed RM ctrl call cmd:0x731341 result 0xffff:
  - r8168  Copyright (C) 2024 Realtek NIC software team <nicfae@realtek.com> This program comes with ABSOLUTELY NO WARRANTY; for details, please see <http://www.gnu.org/licenses/>. This is free software, and you are welcome to redistribute it under certain conditions; see <http://www.gnu.org/licenses/>.

# Tests

Run the following commands on AGX Orin, and on Orin Nano/NX devices.
```
git clone https://github.com/canonical/tegra-tests.git -b jetpack6.x
sudo tegra-tests/tests/boot.py -s -v logs
```
[tegra-tests-results.zip](https://github.com/user-attachments/files/22434457/tegra-tests-results.zip)
